### PR TITLE
Fixed missing scrollbar on list of password banks

### DIFF
--- a/app/styles/areas/_open.scss
+++ b/app/styles/areas/_open.scss
@@ -54,6 +54,8 @@
             flex-direction: column;
             justify-content: flex-start;
             position: relative;
+            max-height: 50vh;
+            overflow-y: auto;
             .open--drag & {
                 display: none;
             }


### PR DESCRIPTION
After change gif:
![scrollbar](https://user-images.githubusercontent.com/7398264/217848594-dc9ee84c-09ad-45ac-bed1-9d53f656eded.gif)
